### PR TITLE
Fix pawns picking up stacks of desserts

### DIFF
--- a/1.5/Defs/ThingDefs_Items/Items_Desserts.xml
+++ b/1.5/Defs/ThingDefs_Items/Items_Desserts.xml
@@ -41,6 +41,7 @@
 			<tasteThought>VCE_AteSimpleDessert</tasteThought>
 			<joyKind>VCE_Confectionery</joyKind>
 			<maxNumToIngestAtOnce>1</maxNumToIngestAtOnce>
+			<defaultNumToIngestAtOnce>1</defaultNumToIngestAtOnce>
 			<ingestSound>Meal_Eat</ingestSound>
 			<ingestEffect>EatVegetarian</ingestEffect>
 		</ingestible>
@@ -100,6 +101,7 @@
 			<tasteThought>VCE_AteFineDessert</tasteThought>
 			<joyKind>VCE_Confectionery</joyKind>
 			<maxNumToIngestAtOnce>1</maxNumToIngestAtOnce>
+			<defaultNumToIngestAtOnce>1</defaultNumToIngestAtOnce>
 			<ingestSound>Meal_Eat</ingestSound>
 			<ingestEffect>EatVegetarian</ingestEffect>
 		</ingestible>
@@ -158,6 +160,7 @@
 			<joyKind>VCE_Confectionery</joyKind>
 			<chairSearchRadius>9</chairSearchRadius>
 			<maxNumToIngestAtOnce>1</maxNumToIngestAtOnce>
+			<defaultNumToIngestAtOnce>1</defaultNumToIngestAtOnce>
 			<ingestSound>Meal_Eat</ingestSound>
 			<ingestEffect>EatVegetarian</ingestEffect>
 		</ingestible>
@@ -217,6 +220,7 @@
 			<chairSearchRadius>9</chairSearchRadius>
 			<optimalityOffsetHumanlikes>1</optimalityOffsetHumanlikes>
 			<maxNumToIngestAtOnce>1</maxNumToIngestAtOnce>
+			<defaultNumToIngestAtOnce>1</defaultNumToIngestAtOnce>
 			<ingestSound>Meal_Eat</ingestSound>
 			<ingestEffect>EatVegetarian</ingestEffect>
 		</ingestible>


### PR DESCRIPTION
The issue happens due to `defaultNumToIngestAtOnce` never being set. This value defaults to 20, unless inherited. However, VCE desserts do not inherit from anything that sets that value at any point.

`defaultNumToIngestAtOnce` specifies the amount of ingestible a pawn will attempt to pick up (in some, but not all situations), while `maxNumToIngestAtOnce` limits how many they can eat at a time (even if they're carrying more than that). Depending on the type of ingestible, `maxNumToIngestAtOnce` may also limit the amount a pawn picks up (specifically for non-drug ingestibles, and desserts are technically considered a drug in here).